### PR TITLE
feat: add --hide flag to allow hiding one or many properties

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+ARGS ?=
+
+.PHONY: test
+test:
+	TZ=UTC go test ./... $(ARGS)

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ Additionally, you can configure your output with these options:
   --time-in string     given time format used by time property. Uses go's time convention; or use 'Unix' | 'UnixMilli' | 'UnixMicro' for Unix epoch timestamps.(default "RFC3339")
   --time-out string    print time in this format. Uses go's time convention (default "15:04:05.000")
   --emoji              display levels as emoji instead of text
-  --linebreak string   "always" | only after "json" | "never" ()
+  --linebreak string   "always" | only after "json" | "never" (default: always)
+  --hide string        hide a property. Use the flag multiple times to hide more than one.
 ```
 
 For defining your own time input and output format refer to the go documentation of the [time format module](https://go.dev/src/time/format.go)
@@ -101,8 +102,6 @@ Protips:
 - Alias axt with your runtime flags to a command that makes it shorter to use
   ```bash
   "alias and-my-axt=axt -m EventName -t Timestamp -l SeverityText --time-in Unix --time-out 15:04:05.000000 --emoji --linebreak never"
-  ```
-  ```
   ```
 
 - Add the pipe through axt in a Makefile of your project for the benefit of your colleagues
@@ -167,9 +166,14 @@ slsa-verifier verify-artifact axt-darwin-arm64 \
   --source-tag v0.5.2
 ```
 
+## Development
+
+As a handy helper during development use `debug/debug.go` to simulate a server.
+
+1. Build the axt binary with `go build -o axt`
+2. Use the binary on the debug file: `go run debug/debug.go | ./axt
+
 ## Roadmap
 
-- [x] Allow formatting time output more freely
-- [ ] Hide properties with a `--hide` option
 - [ ] Color theming
 - [ ] Property highlighting

--- a/cli_test.go
+++ b/cli_test.go
@@ -1,0 +1,225 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/spf13/pflag"
+)
+
+var ansiRegex = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+// ansiRegex strips ANSI color codes from the output
+func stripAnsi(s string) string {
+	return ansiRegex.ReplaceAllString(s, "")
+}
+
+// captureOutput runs the main function with specified arguments and input,
+// and returns the captured standard output.
+func captureOutput(t *testing.T, args []string, input string) string {
+	// Keep track of the original os variables to restore them later
+	oldArgs := os.Args
+	oldStdin := os.Stdin
+	oldStdout := os.Stdout
+	defer func() {
+		os.Args = oldArgs
+		os.Stdin = oldStdin
+		os.Stdout = oldStdout
+	}()
+
+	// Create a pipe to simulate stdin.
+	// We'll write our test input to the writer end.
+	rIn, wIn, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create stdin pipe: %v", err)
+	}
+	os.Stdin = rIn
+
+	// Create a pipe to capture stdout.
+	// We'll read the application's output from the reader end.
+	rOut, wOut, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create stdout pipe: %v", err)
+	}
+	os.Stdout = wOut
+
+	// Set the command-line arguments for this test case.
+	// The first argument is always the program name.
+	os.Args = append([]string{"axt"}, args...)
+
+	// Write the test input to our stdin pipe in a separate goroutine.
+	// This prevents the test from deadlocking.
+	go func() {
+		defer wIn.Close()
+		_, err := io.WriteString(wIn, input)
+		if err != nil {
+			t.Errorf("failed to write to stdin pipe: %v", err)
+		}
+	}()
+
+	// Run the application's main function.
+	main()
+
+	// Close the stdout writer and read the captured output.
+	wOut.Close()
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, rOut)
+	if err != nil {
+		t.Errorf("failed to read from stdout pipe: %v", err)
+	}
+
+	return buf.String()
+}
+
+func TestMainFunction(t *testing.T) {
+	testCases := []struct {
+		name     string
+		args     []string
+		input    string
+		expected string // Expected output, can be multi-line.
+		useUTC   bool
+	}{
+		{
+			name:   "Default slog format",
+			args:   []string{},
+			useUTC: false,
+			input:  `{"time":"2025-08-24T21:51:45.549605+02:00","level":"INFO","msg":"API request completed","status_code":200,"response_time_ms":127}`,
+			expected: `
+ 21:51:45.549 INFO  API request completed
+                   status_code: 200
+                   response_time_ms: 127
+`,
+		},
+		{
+			name:     "Unstructured non-JSON log",
+			args:     []string{},
+			useUTC:   false,
+			input:    `something without proper JSON`,
+			expected: `🪵  something without proper JSON`,
+		},
+		{
+			name:   "Custom flags for ECS",
+			args:   []string{"-t", "@timestamp", "-l", "log.level", "-m", "message"},
+			useUTC: false,
+			input:  `{"@timestamp":"2025-08-24T21:51:45.549Z","log.level":"ERROR","message":"User authentication failed","error.message":"invalid credentials"}`,
+			expected: `
+ 21:51:45.549 ERR   User authentication failed
+                   error.message: "invalid credentials"
+`,
+		},
+		{
+			name:   "Emoji flag for levels",
+			args:   []string{"--emoji"},
+			useUTC: false,
+			input:  `{"time":"2025-08-24T21:51:45.549Z","level":"WARN","msg":"Deprecated API used"}`,
+			expected: `
+ 21:51:45.549 ⚠️  Deprecated API used
+`,
+		},
+		{
+			name:   "Hide properties from output",
+			args:   []string{"--hide", "trace_id", "--hide", "user_agent"},
+			useUTC: false,
+			input:  `{"time":"2025-08-24T21:51:45.549Z","level":"INFO","msg":"Request received","trace_id":"xyz","user_agent":"test-runner","important": true}`,
+			expected: `
+ 21:51:45.549 INFO  Request received
+                   important: true
+`,
+		},
+		{
+			name:   "Custom time out format",
+			args:   []string{"--time-out", "2006/01/02 15h04m05s.000"},
+			useUTC: true,
+			input:  `{"time":"2025-08-24T21:51:45.549Z","level":"DEBUG","msg":"whatever floats your boat time format test"}`,
+			expected: `
+ 2025/08/24 21h51m45s.549 DEBUG whatever floats your boat time format test
+`,
+		},
+		{
+			name:   "Custom time in format - UnixMilli",
+			args:   []string{"--time-in", "UnixMilli", "--time-out", "15:04:05.000"},
+			useUTC: true,
+			input:  `{"time":"1756555555123","level":"DEBUG","msg":"Timestamp test"}`,
+			expected: `
+		  12:05:55.123 DEBUG Timestamp test
+		 `,
+		},
+		{
+			name:   "Custom time in format - Unix with decimal",
+			args:   []string{"--time-in", "Unix"},
+			useUTC: true,
+			input:  `{"time":"1756555555.123","level":"DEBUG","msg":"Timestamp test"}`,
+			expected: `
+		  12:05:55.123 DEBUG Timestamp test
+		 `,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.useUTC {
+				setTestTimezone(t, "UTC")
+			}
+
+			// Reset the command-line flags before each test run.
+			// The main() function registers flags, and calling it in a loop
+			// would cause a "flag redefined" panic if we didn't reset.
+			pflag.CommandLine = pflag.NewFlagSet(os.Args[0], pflag.ExitOnError)
+
+			actualRaw := captureOutput(t, tc.args, tc.input)
+			actualClean := strings.TrimSpace(stripAnsi(actualRaw))
+			expectedClean := strings.TrimSpace(tc.expected)
+
+			expectedLines := strings.Split(expectedClean, "\n")
+			actualLines := strings.Split(actualClean, "\n")
+
+			// Compare the first line (the header) directly
+			if strings.TrimSpace(actualLines[0]) != strings.TrimSpace(expectedLines[0]) {
+				t.Errorf("Header line mismatch.\n--- Expected ---\n%s\n--- Actual ---\n%s", expectedLines[0], actualLines[0])
+				return
+			}
+
+			// For the remaining lines (properties), their order isn't guaranteed.
+			// We just check that each expected property line is present in the actual output.
+			if len(expectedLines) > 1 {
+				for _, expectedLine := range expectedLines[1:] {
+					trimmedExpected := strings.TrimSpace(expectedLine)
+					found := false
+					for _, actualLine := range actualLines[1:] {
+						if strings.TrimSpace(actualLine) == trimmedExpected {
+							found = true
+							break
+						}
+					}
+					if !found {
+						t.Errorf("Expected property line not found in output.\n--- Missing Line ---\n%s\n--- Actual Output ---\n%s", trimmedExpected, actualClean)
+					}
+				}
+			}
+		})
+	}
+}
+
+// setTestTimezone sets the local timezone for the duration of a test.
+func setTestTimezone(t *testing.T, tz string) {
+	// t.Helper() marks this function as a test helper.
+	// When a test fails, the file and line number of the caller will be reported,
+	// not the location inside this helper.
+	t.Helper()
+
+	// Get the original timezone to restore it later
+	originalTZ := os.Getenv("TZ")
+
+	// Set the desired timezone
+	os.Setenv("TZ", tz)
+
+	// Use t.Cleanup to restore the original timezone after the test is done.
+	// This function will be called automatically at the end of the test.
+	t.Cleanup(func() {
+		os.Setenv("TZ", originalTZ)
+	})
+}

--- a/debug/debug.go
+++ b/debug/debug.go
@@ -1,14 +1,14 @@
+//go:build debug
+
 package main
 
 import (
 	"fmt"
 	"log/slog"
 	"os"
-	"time"
 )
 
 func main() {
-	// Configure JSON logger
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
 
 	// Basic log messages with different levels
@@ -17,26 +17,21 @@ func main() {
 	logger.Warn("This is a warning message")
 	logger.Error("This is an error message")
 
-	// Log with string attributes
+	// Log strings properties
 	logger.Info("User logged in",
 		slog.String("username", "johndoe"),
 		slog.String("ip", "192.168.1.1"))
 
-	// Log with numeric attributes
+	// Log numbers and bools
 	logger.Info("API request completed",
 		slog.Int("status_code", 200),
 		slog.Int64("response_time_ms", 127),
-		slog.Float64("response_size_kb", 24.7))
-
-	// Log with boolean attributes
-	logger.Info("Feature flags status",
-		slog.Bool("dark_mode", true),
-		slog.Bool("beta_features", false),
-		slog.Any("thingy", nil))
+		slog.Float64("response_size_kb", 24.7),
+		slog.Bool("beta_features", false))
 
 	fmt.Println("something without proper JSON")
 
-	// Log with complex JSON structure using Any
+	// Log complex JSON structure
 	user := map[string]any{
 		"id":       12345,
 		"username": "alice",
@@ -49,15 +44,11 @@ func main() {
 	}
 	logger.Info("User profile", slog.Any("user", user))
 
-	// Log with array/slice
+	// Log array
 	tags := []string{"go", "logging", "slog", "json"}
 	logger.Info("Article published",
 		slog.String("title", "Structured Logging in Go"),
 		slog.Any("tags", tags))
-
-	// Log with time
-	logger.Info("Event scheduled",
-		slog.Time("scheduled_at", time.Now().Add(24*time.Hour)))
 
 	// Log with nested error
 	logger.Error("Database connection failed",
@@ -74,25 +65,6 @@ func main() {
 			},
 		}))
 
-	// Mixed types in a single log
-	logger.Info("Order processed",
-		slog.Int("order_id", 987654),
-		slog.String("customer", "ACME Corp"),
-		slog.Float64("total", 299.99),
-		slog.Bool("expedited", true),
-		slog.Any("items", []map[string]any{
-			{
-				"product_id": "ABC123",
-				"quantity":   2,
-				"price":      149.99,
-			},
-			{
-				"product_id": "XYZ789",
-				"quantity":   1,
-				"price":      0.01,
-			},
-		}))
-
 	badLogger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
 		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
 			switch a.Key {
@@ -103,11 +75,9 @@ func main() {
 			case slog.LevelKey:
 				a.Key = "logLevel"
 			}
-
 			return a
 		},
 	}))
-
 	badLogger.Info("big chaos",
 		slog.Float64("total", 299.99),
 		slog.Bool("expedited", true),
@@ -140,4 +110,9 @@ func main() {
 				"price":      0.01,
 			},
 		}))
+
+	// Epoch time to test --time-in Unix (use with -t timestamp)
+	logger.Info("Epoch Time",
+		slog.String("timestamp", "1756555555"),
+	)
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24.0
 
 require (
 	github.com/pterm/pterm v0.12.80
+	github.com/spf13/pflag v1.0.7
 	github.com/tidwall/pretty v1.2.1
 )
 
@@ -16,7 +17,6 @@ require (
 	github.com/lithammer/fuzzysearch v1.1.8 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
-	github.com/spf13/pflag v1.0.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/sys v0.27.0 // indirect
 	golang.org/x/term v0.26.0 // indirect

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("TZ") != "UTC" {
+		fmt.Println("Error: Tests must be run with the 'TZ=UTC' environment variable.")
+		fmt.Println("E.g. run tests with 'TZ=UTC go test ./...'.")
+		os.Exit(1)
+	}
+
+	os.Exit(m.Run())
+}

--- a/time.go
+++ b/time.go
@@ -69,7 +69,7 @@ func formatTime(timeStr, inputFormat, outputFormat string) string {
 
 	switch layout {
 	case unixStrategy:
-		parsedTime, err = parseUnix(layout, timeStr)
+		parsedTime, err = parseUnix(inputFormat, timeStr)
 	default:
 		parsedTime, err = time.Parse(layout, timeStr)
 	}


### PR DESCRIPTION
fix: an issue where timestamps parsing with --time-in would be ignored
refactor: move test/test.go to debug and use build flag
test: add integration tests